### PR TITLE
Bottom navigation & named routes

### DIFF
--- a/lib/chat_page.dart
+++ b/lib/chat_page.dart
@@ -1,15 +1,21 @@
 import 'package:flutter/material.dart';
 
-class ChatPage extends StatelessWidget {
+class ChatPageArgs {
   final String username;
 
-  ChatPage({Key key, @required this.username}) : super(key: key);
+  ChatPageArgs(this.username);
+}
+
+class ChatPage extends StatelessWidget {
+  static const routeName = '/chat';
 
   @override
   Widget build(BuildContext context) {
+    final ChatPageArgs args = ModalRoute.of(context).settings.arguments;
+
     return Scaffold(
       appBar: AppBar(
-        title: Text(username),
+        title: Text(args.username),
       ),
       body: Center(),
     );

--- a/lib/conversations_page.dart
+++ b/lib/conversations_page.dart
@@ -52,13 +52,10 @@ class _ConversationListState extends State<ConversationList> {
                 title: Text(userNames[index]),
                 subtitle: Text(mockMessages[index]),
                 onTap: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                        builder: (context) => ChatPage(
-                              username: userNames[index],
-                            )),
-                  );
+                  Navigator.pushNamed(context, ChatPage.routeName,
+                      arguments: ChatPageArgs(
+                        userNames[index],
+                      ));
                 },
               );
             }),

--- a/lib/conversations_page.dart
+++ b/lib/conversations_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:meetup_chatapp/chat_page.dart';
-import 'package:meetup_chatapp/options_page.dart';
 
 class ConversationsPage extends StatelessWidget {
   @override
@@ -10,15 +9,7 @@ class ConversationsPage extends StatelessWidget {
         // Here we take the value from the MyHomePage object that was created by
         // the App.build method, and use it to set our appbar title.
         leading: Icon(Icons.account_circle, size: 50),
-        title: Text("Adventures.in Messenger"),
-        actions: <Widget>[
-          IconButton(
-              icon: Icon(Icons.settings),
-              onPressed: () {
-                Navigator.push(context,
-                    MaterialPageRoute(builder: (context) => OptionsPage()));
-              }),
-        ],
+        title: Text("Chats"),
       ),
 
       body: ConversationList(),

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:meetup_chatapp/conversations_page.dart';
+import 'package:meetup_chatapp/options_page.dart';
+
+class HomePage extends StatefulWidget {
+  @override
+  State<StatefulWidget> createState() => HomePageState();
+}
+
+class HomePageState extends State<HomePage> {
+  int _currentIndex = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: IndexedStack(
+        index: _currentIndex,
+        children: <Widget>[
+          ConversationsPage(),
+          OptionsPage(),
+        ],
+      ),
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _currentIndex,
+        items: const <BottomNavigationBarItem>[
+          BottomNavigationBarItem(icon: Icon(Icons.chat), title: Text("Chats")),
+          BottomNavigationBarItem(
+              icon: Icon(Icons.settings), title: Text("Settings")),
+        ],
+        onTap: (int index) {
+          setState(() {
+            _currentIndex = index;
+          });
+        },
+        selectedItemColor: Theme.of(context).accentColor,
+      ),
+    );
+  }
+}

--- a/lib/landing.dart
+++ b/lib/landing.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+
+class LandingPage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(body: Center(child: CircularProgressIndicator()));
+  }
+}

--- a/lib/link_accounts_page.dart
+++ b/lib/link_accounts_page.dart
@@ -5,6 +5,8 @@ import 'package:flutter_facebook_login/flutter_facebook_login.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 
 class LinkAccountsPage extends StatelessWidget {
+  static final routeName = '/link_accounts';
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:meetup_chatapp/auth_page.dart';
 import 'package:meetup_chatapp/home.dart';
+import 'package:meetup_chatapp/landing.dart';
 
 void main() => runApp(MyApp());
 
@@ -16,11 +17,13 @@ class MyApp extends StatelessWidget {
         home: StreamBuilder(
           stream: FirebaseAuth.instance.onAuthStateChanged,
           builder: (context, snapshot) {
-            if (snapshot.hasData) {
-              return HomePage();
-            } else {
-              return AuthPage();
+            if (snapshot.connectionState == ConnectionState.active) {
+              return snapshot.hasData ? HomePage() : AuthPage();
             }
+
+            return Center(
+              child: LandingPage(),
+            );
           },
         ));
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:meetup_chatapp/auth_page.dart';
-import 'package:meetup_chatapp/conversations_page.dart';
+import 'package:meetup_chatapp/home.dart';
 
 void main() => runApp(MyApp());
 
@@ -17,7 +17,7 @@ class MyApp extends StatelessWidget {
           stream: FirebaseAuth.instance.onAuthStateChanged,
           builder: (context, snapshot) {
             if (snapshot.hasData) {
-              return ConversationsPage();
+              return HomePage();
             } else {
               return AuthPage();
             }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,11 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:meetup_chatapp/auth_page.dart';
+import 'package:meetup_chatapp/chat_page.dart';
 import 'package:meetup_chatapp/home.dart';
-import 'package:meetup_chatapp/landing.dart';
+import 'package:meetup_chatapp/splash.dart';
+import 'package:meetup_chatapp/link_accounts_page.dart';
+import 'package:meetup_chatapp/profile_page.dart';
 
 void main() => runApp(MyApp());
 
@@ -10,21 +13,29 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-        title: 'Flutter Demo',
-        theme: ThemeData(
-          primarySwatch: Colors.blue,
-        ),
-        home: StreamBuilder(
-          stream: FirebaseAuth.instance.onAuthStateChanged,
-          builder: (context, snapshot) {
-            if (snapshot.connectionState == ConnectionState.active) {
-              return snapshot.hasData ? HomePage() : AuthPage();
+      title: 'Flutter Demo',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: StreamBuilder(
+        stream: FirebaseAuth.instance.onAuthStateChanged,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.active) {
+            if (snapshot.hasData) {
+              return HomePage();
+            } else {
+              return AuthPage();
             }
+          }
 
-            return Center(
-              child: LandingPage(),
-            );
-          },
-        ));
+          return SplashPage();
+        },
+      ),
+      routes: {
+        ChatPage.routeName: (context) => ChatPage(),
+        ProfilePage.routeName: (context) => ProfilePage(),
+        LinkAccountsPage.routeName: (context) => LinkAccountsPage(),
+      },
+    );
   }
 }

--- a/lib/options_page.dart
+++ b/lib/options_page.dart
@@ -55,8 +55,6 @@ class OptionsPage extends StatelessWidget {
                               await FirebaseAuth.instance.signOut();
 
                               Navigator.pop(dialogContext);
-                              Navigator.pop(
-                                  context); // TODO remove this once the navigation has been switched to a bottom app bar
                             },
                           )
                         ],

--- a/lib/options_page.dart
+++ b/lib/options_page.dart
@@ -8,7 +8,7 @@ class OptionsPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: AppBar(),
+        appBar: AppBar(title: Text("Settings")),
         body: ListView(
           padding: const EdgeInsets.symmetric(vertical: 20),
           children: <Widget>[

--- a/lib/options_page.dart
+++ b/lib/options_page.dart
@@ -1,8 +1,7 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:meetup_chatapp/link_accounts_page.dart';
 import 'package:meetup_chatapp/profile_page.dart';
-
-import 'link_accounts_page.dart';
 
 class OptionsPage extends StatelessWidget {
   @override
@@ -16,9 +15,9 @@ class OptionsPage extends StatelessWidget {
               leading: const Icon(Icons.account_circle, size: 32),
               title: const Text("View Profile"),
               onTap: () {
-                Navigator.push(
+                Navigator.pushNamed(
                   context,
-                  MaterialPageRoute(builder: (context) => ProfilePage()),
+                  ProfilePage.routeName,
                 );
               },
             ),
@@ -66,10 +65,7 @@ class OptionsPage extends StatelessWidget {
               leading: const Icon(Icons.link, size: 32),
               title: const Text("Link Accounts"),
               onTap: () {
-                Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                        builder: (context) => LinkAccountsPage()));
+                Navigator.pushNamed(context, LinkAccountsPage.routeName);
               },
             ),
           ],

--- a/lib/profile_page.dart
+++ b/lib/profile_page.dart
@@ -1,8 +1,9 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_auth_buttons/flutter_auth_buttons.dart';
 
 class ProfilePage extends StatelessWidget {
+  static final routeName = '/profile';
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(

--- a/lib/splash.dart
+++ b/lib/splash.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-class LandingPage extends StatelessWidget {
+class SplashPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(body: Center(child: CircularProgressIndicator()));


### PR DESCRIPTION
I created a HomePage that contains the top pages of the authenticated navigation flow. It uses a BottomNavigationBar to switch between the ConversationPage and the OptionsPage. All the other routes are reachable by using their `routeName` attribute together with the `Navigator.pushNamed` method.

I wanted to switch between SplashPage, AuthPage and HomePage using `Navigator.replaceNamed`, but I couldn't get it to work, and at this point, I'm not even sure it is necessary, so I left the signin/signout flow mostly as it was before.

I tried the changes on Android and they seem to work. Could you test them on iOS?