### PR TITLE
Add background bubble to chat messages

### DIFF
--- a/lib/chat_page.dart
+++ b/lib/chat_page.dart
@@ -1,3 +1,4 @@
+import 'package:adventures_in_chat_app/widgets/chat_message.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:adventures_in_chat_app/models/conversation_item.dart';
@@ -7,9 +8,11 @@ class ChatPage extends StatefulWidget {
     @required this.conversationItem,
     @required this.currentUserId,
   });
+
   static const routeName = '/chat';
   final ConversationItem conversationItem;
   final String currentUserId;
+
   @override
   _ChatPageState createState() => _ChatPageState();
 }
@@ -37,9 +40,7 @@ class _ChatPageState extends State<ChatPage> {
               itemCount: querySnapshot.documents.length,
               itemBuilder: (context, index) {
                 final doc = querySnapshot.documents[index];
-                return ListTile(
-                  title: Text(doc.data['text'] as String),
-                );
+                return ChatMessage(text: doc.data['text'] as String);
               });
         },
       ),

--- a/lib/widgets/chat_message.dart
+++ b/lib/widgets/chat_message.dart
@@ -9,15 +9,22 @@ class ChatMessage extends StatelessWidget {
   Widget build(BuildContext context) {
     var theme = Theme.of(context);
 
-    return ListTile(
-      title: Text(text,
-          style: theme.textTheme.bodyText1.merge(TextStyle(
-              fontSize: 20,
-              background: Paint()
-                ..strokeWidth = 30.0
-                ..color = theme.backgroundColor
-                ..style = PaintingStyle.stroke
-                ..strokeJoin = StrokeJoin.round))),
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      mainAxisSize: MainAxisSize.max,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+            padding: EdgeInsets.all(16.0),
+            child: Text(text,
+                style: theme.textTheme.bodyText1.merge(TextStyle(
+                    fontSize: 20,
+                    background: Paint()
+                      ..strokeWidth = 30.0
+                      ..color = theme.backgroundColor
+                      ..style = PaintingStyle.stroke
+                      ..strokeJoin = StrokeJoin.round)))),
+      ],
     );
   }
 }

--- a/lib/widgets/chat_message.dart
+++ b/lib/widgets/chat_message.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+class ChatMessage extends StatelessWidget {
+  final String text;
+
+  const ChatMessage({Key key, this.text}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    var theme = Theme.of(context);
+
+    return ListTile(
+      title: Text(text,
+          style: theme.textTheme.bodyText1.merge(TextStyle(
+              fontSize: 20,
+              background: Paint()
+                ..strokeWidth = 30.0
+                ..color = theme.backgroundColor
+                ..style = PaintingStyle.stroke
+                ..strokeJoin = StrokeJoin.round))),
+    );
+  }
+}


### PR DESCRIPTION
Solves #69 
![Screenshot_1585731328](https://user-images.githubusercontent.com/1693076/78118458-c2a5af80-7452-11ea-977d-eeb511a4b417.png)

I replaced ListTile with a Column widget, since the `ListTile.title` text is not supposed to wrap, and the `ListTile.subtitle` should be 2 lines at most. This should also make things easier when we decide to add more data to the message (username, timestamp...).