### PR TITLE
[Android] Fix cut messages list on virtual keyboard open

### DIFF
--- a/lib/chat_page.dart
+++ b/lib/chat_page.dart
@@ -22,44 +22,41 @@ class _ChatPageState extends State<ChatPage> {
 
   @override
   Widget build(BuildContext context) {
-    final mediaQuery = MediaQuery.of(context);
-    return Container(
-      padding: EdgeInsets.only(
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: mediaQuery.viewInsets.bottom,
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.conversationItem.conversationId),
       ),
-      child: Scaffold(
-        appBar: AppBar(
-          title: Text(widget.conversationItem.conversationId),
-        ),
-        body: StreamBuilder(
-          stream: Firestore.instance
-              .collection(
-                  'conversations/${widget.conversationItem.conversationId}/messages')
-              .snapshots(),
-          builder: (context, snapshot) {
-            if (!snapshot.hasData) {
-              return Container();
-            }
-            final querySnapshot = snapshot.data as QuerySnapshot;
-            return ListView.builder(
-                itemCount: querySnapshot.documents.length,
-                itemBuilder: (context, index) {
-                  final doc = querySnapshot.documents[index];
-                  return ChatMessage(text: doc.data['text'] as String);
-                });
-          },
-        ),
-        resizeToAvoidBottomInset: true,
-        bottomNavigationBar: BottomAppBar(
-          child: BottomChatBar(
-            conversationId: widget.conversationItem.conversationId,
-            currentUserId: widget.currentUserId,
+      body: Column(
+        children: <Widget>[
+          Expanded(
+            child: StreamBuilder(
+              stream: Firestore.instance
+                  .collection(
+                      'conversations/${widget.conversationItem.conversationId}/messages')
+                  .snapshots(),
+              builder: (context, snapshot) {
+                if (!snapshot.hasData) {
+                  return Container();
+                }
+                final querySnapshot = snapshot.data as QuerySnapshot;
+                return ListView.builder(
+                    itemCount: querySnapshot.documents.length,
+                    itemBuilder: (context, index) {
+                      final doc = querySnapshot.documents[index];
+                      return ChatMessage(text: doc.data['text'] as String);
+                    });
+              },
+            ),
           ),
-        ),
+          BottomAppBar(
+            child: BottomChatBar(
+              conversationId: widget.conversationItem.conversationId,
+              currentUserId: widget.currentUserId,
+            ),
+          ),
+        ],
       ),
+      resizeToAvoidBottomInset: true,
     );
   }
 }


### PR DESCRIPTION
The solution used in #82 has a strange effect on the chat page on Android, when opening the virtual keyboard: the messages list gets cut. This may be caused by using MediaQueryData.viewInsets together with `resizeToAvoidBottomInset`, but since this worked correctly on iOS, I'm not sure.
![chat_page_before_resized](https://user-images.githubusercontent.com/1693076/78967333-8571a980-7b45-11ea-9c14-9c8edfe0c283.gif)

I tried the solution described in [this comment](https://stackoverflow.com/a/51336745) from the StackOverflow thread posted in #79 to avoid using MediaQuery and let the OS take care of the resizing.
![chat_page_after_resized](https://user-images.githubusercontent.com/1693076/78967471-ed27f480-7b45-11ea-9a06-00071f169c15.gif)

I haven't tested this on iOS, so I don't know if this works properly on it too. Could you check if this solution works?