### PR TITLE
Add app_identifier and username to Matchfile

### DIFF
--- a/ios/fastlane/Matchfile
+++ b/ios/fastlane/Matchfile
@@ -4,8 +4,8 @@ storage_mode("google_cloud")
 
 type("development") # The default type, can be: appstore, adhoc, enterprise or development
 
-# app_identifier(["tools.fastlane.app", "tools.fastlane.app2"])
-# username("user@fastlane.tools") # Your Apple Developer Portal username
+app_identifier(["co.enspyr.AdventuresInChatApp"])
+username("ci@enspyr.co") # Your Apple Developer Portal username
 
 # For all available options run `fastlane match --help`
 # Remove the # in the beginning of the line to enable the other options


### PR DESCRIPTION
I've been wrestling with code signing errors and realised the `app_identifier` and `username` were not set in the Matchfile - I think my problem was a local configuration thing but it's a good idea to specify the values anyway I think. 