### PR TITLE
Fix for range issue by connection state waiting

### DIFF
--- a/lib/conversations_page.dart
+++ b/lib/conversations_page.dart
@@ -67,7 +67,10 @@ class _ConversationListState extends State<ConversationList> {
                 .where('uids', arrayContains: currentUserId)
                 .snapshots(),
             builder: (context, snapshot) {
-              if (!snapshot.hasData) return CircularProgressIndicator();
+              if (!snapshot.hasData ||
+                  snapshot.connectionState == ConnectionState.waiting) {
+                return CircularProgressIndicator();
+              }
 
               final querySnapshot = snapshot.data as QuerySnapshot;
               Provider.of<ConversationsViewModel>(context).populateWith(


### PR DESCRIPTION
Ideally this would be fixed with unittest though a bit overwhelmed with the amount of work required to decouple the _ConversationListState with firestore to allow testing by mock / fake or inject.

Though after seeing the following [snippet](https://pub.dev/packages/cloud_firestore) I noticed some robustness was missed out of our implementation with regards to connection state. That or this is a feature since introduced.