### PR TITLE
Avoid unnecessary CI runs

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -1,10 +1,6 @@
 name: Mobile Apps
 
 on:
-  push:
-    branches:
-      - dev
-      - master
   pull_request:
     branches:
       - dev


### PR DESCRIPTION
Fixes #169

- removed config steps in workflow file that triggered CI on push

#### from issue

> My thinking is that - given branches pushed onto `dev` are required to be up to date, there is no need to do a CI run on push.  I would appreciate a sanity check and will put up a PR in the meantime. 
