### PR TITLE
i181: Add function to ConversationItem to print truncated list of names

### DIFF
--- a/lib/conversations_page.dart
+++ b/lib/conversations_page.dart
@@ -93,7 +93,7 @@ class ConversationsListTile extends StatelessWidget {
   Widget build(BuildContext context) {
     return ListTile(
       leading: UserAvatar(url: item.photoURLs.first),
-      title: Text(_combine(item.displayNames)),
+      title: Text(item.truncatedNames(15)),
       subtitle: Text('Coming soon.'),
       onTap: () {
         Navigator.pushNamed(context, ChatPage.routeName,
@@ -102,10 +102,6 @@ class ConversationsListTile extends StatelessWidget {
                 conversationItem: item));
       },
     );
-  }
-
-  String _combine(List<String> displayNames) {
-    return displayNames.join(', ');
   }
 }
 

--- a/lib/models/conversation_item.dart
+++ b/lib/models/conversation_item.dart
@@ -14,6 +14,14 @@ class ConversationItem {
   final List<String> displayNames;
   final List<String> photoURLs;
 
+  // generate a truncated string of the combined display names
+  String truncatedNames(int cutoff) {
+    final joined = displayNames?.join(', ') ?? '';
+    return (joined.length <= cutoff)
+        ? joined
+        : '${joined.substring(0, cutoff)}...';
+  }
+
   // Conversation items with the same conversationId are considered equivalent
   @override
   bool operator ==(dynamic o) =>

--- a/test/conversations_page_test.dart
+++ b/test/conversations_page_test.dart
@@ -13,7 +13,7 @@ void main() {
     testWidgets('find conversationId, uids, displaynames and photoURLs',
         (WidgetTester tester) async {
       final fake = FakeDatabase();
-      fake.add(ConversationItem(conversationId: 'abc123', uids: [
+      final item = ConversationItem(conversationId: 'abc123', uids: [
         '123',
         '456'
       ], displayNames: [
@@ -22,7 +22,8 @@ void main() {
       ], photoURLs: [
         'https://example.com/leon.png',
         'https://example.com/noel.png'
-      ]));
+      ]);
+      fake.add(item);
 
       final db = DatabaseService(database: fake);
 
@@ -40,13 +41,13 @@ void main() {
 
         await tester.pumpAndSettle();
 
-        expect(find.text('Leon, Noel'), findsOneWidget);
+        expect(find.text(item.truncatedNames(15)), findsOneWidget);
       });
     });
     testWidgets('no exception when null displaynames',
         (WidgetTester tester) async {
       final fake = FakeDatabase();
-      fake.add(ConversationItem(conversationId: 'abc123', uids: [
+      final item = ConversationItem(conversationId: 'abc123', uids: [
         '123',
         '456',
         'abc'
@@ -58,7 +59,8 @@ void main() {
         'https://example.com/leon.png',
         'https://example.com/noel.png',
         'https://example.com/null.png',
-      ]));
+      ]);
+      fake.add(item);
 
       final db = DatabaseService(database: fake);
 
@@ -76,7 +78,7 @@ void main() {
 
         await tester.pumpAndSettle();
 
-        expect(find.text('Leon, Noel, null'), findsOneWidget);
+        expect(find.text(item.truncatedNames(15)), findsOneWidget);
       });
     });
   });

--- a/test/unit/conversation_item_test.dart
+++ b/test/unit/conversation_item_test.dart
@@ -1,0 +1,18 @@
+import 'package:adventures_in_chat_app/models/conversation_item.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ConversationItem', () {
+    test(
+        '.truncatedNames() combines the display names and truncates to the given cutoff',
+        () {
+      final item = ConversationItem(
+          conversationId: 'id',
+          displayNames: ['a', 'b', 'c'],
+          photoURLs: ['u', 'r', 'l'],
+          uids: ['1', '2', '3']);
+
+      expect(item.truncatedNames(4), 'a, b...');
+    });
+  });
+}

--- a/test/unit/conversations_view_model_test.dart
+++ b/test/unit/conversations_view_model_test.dart
@@ -1,10 +1,9 @@
-// Import the test package and Counter class
 import 'package:adventures_in_chat_app/conversations_page.dart';
 import 'package:adventures_in_chat_app/models/conversation_item.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('ConversationViewModel', () {
+  group('ConversationsViewModel', () {
     test('.add()', () {
       var inject_list = <ConversationItem>[];
       var vm = ConversationsViewModel(inject_list);


### PR DESCRIPTION
Fixes #181

- added a function to ConversationItem to generate a truncated string
of the combined display names
- added a test for the new function
- changed the conversations_page to use the new function
- updated the conversations_page tests
- renamed conversations_page_test to conversations_view_model_test