### PR TITLE
Add test coverage

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -51,7 +51,14 @@ jobs:
     # run tests, build android, build ios
     ##############################################
     - run: flutter pub get
-    - run: flutter test
+    - run: flutter test --coverage
     - run: flutter build appbundle --build-number=$GITHUB_RUN_NUMBER
     - run: flutter build ios --release --no-codesign --build-number=$GITHUB_RUN_NUMBER
 
+    ##############################################
+    # upload coverage to coveralls.io
+    ##############################################
+    - name: Coveralls
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A Chat App for Adventures in Flutter.
 
 ![CI](https://github.com/adventuresin/chat_app/workflows/Mobile%20Apps/badge.svg)
+[![Coverage Status](https://coveralls.io/repos/github/Adventures-In/chat_app/badge.svg)](https://coveralls.io/github/Adventures-In/chat_app)
 
 ## Quickstart Guide 
 


### PR DESCRIPTION
Fixes #187

The badge currently says "coverage unknown" but probably just due to build delays in coveralls process, see: 
https://github.com/lemurheavy/coveralls-public/issues/1274

The only thing I did that isn't in the changes was to go to coveralls.io and sign in with github (not sure if I needed to but thought I would add it here in case anyone uses the PR as a reference).

There's some great info at:
https://coveralls.io/github/Adventures-In/chat_app 