### PR TITLE
Don't repeat date in each message

### DIFF
--- a/lib/extensions/date_time_extensions.dart
+++ b/lib/extensions/date_time_extensions.dart
@@ -1,0 +1,9 @@
+extension DateOnlyCompare on DateTime {
+  bool isSameDate(DateTime other) {
+    return year == other.year && month == other.month && day == other.day;
+  }
+
+  String printDate() {
+    return '$day/$month/$year';
+  }
+}

--- a/lib/extensions/extensions.dart
+++ b/lib/extensions/extensions.dart
@@ -1,2 +1,3 @@
 export 'document_snapshot_extensions.dart';
 export 'build_context_extensions.dart';
+export 'date_time_extensions.dart';

--- a/lib/models/message.dart
+++ b/lib/models/message.dart
@@ -1,4 +1,19 @@
-class Message {
+import 'package:adventures_in_chat_app/extensions/extensions.dart';
+
+abstract class MessagesListItem {
+  String get outputText;
+}
+
+class SectionDate implements MessagesListItem {
+  final DateTime timestamp;
+
+  SectionDate(this.timestamp);
+
+  @override
+  String get outputText => timestamp.printDate();
+}
+
+class Message implements MessagesListItem {
   final String authorId;
   final String text;
   final DateTime timestamp;
@@ -8,4 +23,7 @@ class Message {
     this.text,
     this.timestamp,
   });
+
+  @override
+  String get outputText => text;
 }

--- a/lib/widgets/conversations/user_search_page.dart
+++ b/lib/widgets/conversations/user_search_page.dart
@@ -2,7 +2,6 @@ import 'dart:collection';
 
 import 'package:adventures_in_chat_app/extensions/extensions.dart';
 import 'package:adventures_in_chat_app/models/user_item.dart';
-import 'package:adventures_in_chat_app/services/database_service.dart';
 import 'package:adventures_in_chat_app/widgets/shared/user_avatar.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';

--- a/lib/widgets/messages/chat_message.dart
+++ b/lib/widgets/messages/chat_message.dart
@@ -9,9 +9,6 @@ class ChatMessage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     var theme = Theme.of(context);
-    var formattedDate = (dateTime == null)
-        ? ''
-        : '${dateTime.year}-${dateTime.month}-${dateTime.day} ${dateTime.hour}:${dateTime.minute.toString().padLeft(2, "0")}';
 
     return Column(
       mainAxisAlignment: MainAxisAlignment.start,
@@ -20,24 +17,17 @@ class ChatMessage extends StatelessWidget {
       children: [
         Row(
           children: [
-            Expanded(
-              child: Padding(
-                padding: EdgeInsets.all(16.0),
-                child: Text(text,
-                    style: theme.textTheme.bodyText1.merge(TextStyle(
-                        fontSize: 20,
-                        background: Paint()
-                          ..strokeWidth = 30.0
-                          ..color = theme.backgroundColor
-                          ..style = PaintingStyle.stroke
-                          ..strokeJoin = StrokeJoin.round))),
-              ),
-            ),
             Padding(
-                padding: EdgeInsets.all(16.0),
-                child: Text(formattedDate,
-                    style: theme.textTheme.bodyText1
-                        .merge(TextStyle(fontSize: 12)))),
+              padding: EdgeInsets.all(16.0),
+              child: Text(text,
+                  style: theme.textTheme.bodyText1.merge(TextStyle(
+                      fontSize: 20,
+                      background: Paint()
+                        ..strokeWidth = 30.0
+                        ..color = theme.backgroundColor
+                        ..style = PaintingStyle.stroke
+                        ..strokeJoin = StrokeJoin.round))),
+            ),
           ],
         ),
       ],

--- a/lib/widgets/messages/chat_page.dart
+++ b/lib/widgets/messages/chat_page.dart
@@ -32,7 +32,7 @@ class _ChatPageState extends State<ChatPage> {
       body: Column(
         children: <Widget>[
           Expanded(
-            child: StreamBuilder<List<Message>>(
+            child: StreamBuilder<List<MessagesListItem>>(
               stream: widget.db
                   .getMessagesStream(widget.conversationItem.conversationId),
               builder: (context, snapshot) {
@@ -41,7 +41,7 @@ class _ChatPageState extends State<ChatPage> {
                 }
 
                 return MessagesList(
-                    controller: _controller, messages: snapshot.data);
+                    controller: _controller, items: snapshot.data);
               },
             ),
           ),
@@ -67,12 +67,12 @@ class MessagesList extends StatefulWidget {
   const MessagesList({
     Key key,
     @required ScrollController controller,
-    @required this.messages,
+    @required this.items,
   })  : controller = controller,
         super(key: key);
 
   final ScrollController controller;
-  final List<Message> messages;
+  final List<MessagesListItem> items;
 
   @override
   _MessagesListState createState() => _MessagesListState();
@@ -90,13 +90,26 @@ class _MessagesListState extends State<MessagesList> {
   @override
   Widget build(BuildContext context) {
     return ListView.builder(
-      controller: widget.controller,
-      itemCount: widget.messages.length,
-      itemBuilder: (context, index) => ChatMessage(
-        text: widget.messages[index].text,
-        dateTime: widget.messages[index].timestamp,
-      ),
-    );
+        shrinkWrap: true,
+        controller: widget.controller,
+        itemCount: widget.items.length,
+        itemBuilder: (context, index) {
+          final item = widget.items[index];
+
+          return (item.runtimeType == Message)
+              ? Row(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  children: [
+                    ChatMessage(text: item.outputText),
+                  ],
+                )
+              : Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    ChatMessage(text: item.outputText),
+                  ],
+                );
+        });
   }
 }
 

--- a/test/chat_page_test.dart
+++ b/test/chat_page_test.dart
@@ -18,18 +18,6 @@ void main() {
 
       expect(find.text('Test message'), findsOneWidget);
     });
-
-    testWidgets('Should contain dateTime in chat widget when specified',
-        (WidgetTester tester) async {
-      var dateTime = DateTime.parse('1969-07-20 20:18:04Z');
-      var formattedDate = '1969-7-20 20:18';
-
-      await tester.pumpWidget(
-          wrapWidget(ChatMessage(text: 'Test message', dateTime: dateTime)));
-
-      expect(find.text('Test message'), findsOneWidget);
-      expect(find.text(formattedDate), findsOneWidget);
-    });
   });
 
   group('BottomChatBar', () {

--- a/test/messages_list_test.dart
+++ b/test/messages_list_test.dart
@@ -15,7 +15,7 @@ void main() {
       await tester.pumpWidget(MaterialApp(
           home: MessagesList(
         controller: _controller,
-        messages: messages,
+        items: messages,
       )));
 
       await tester.pumpAndSettle();


### PR DESCRIPTION
Fixes #172

- code is the result of pair programming on sat meetup
- added extension for comparing DateTimes by date only
- added extension for printing a DateTime as date only
- added abstract MessagesListItem for Message & SectionDate to implement
- added a stream controller to database service so we can return the
controller's stream and add to the stream
- change getMessagesStream() to return the stream controller's
stream, listen to the database stream, and add section dates
- remove the date from the ChatMessage widget
- change the ChatPage widget to use the MessageListItem type, and
check for item runtimeType to display the correct widget
- updated tests so current tests pass (no tests added for this feature
yet)

EDIT: added #201 and #202 to track adding tests 