### PR TITLE
stream already been listened to when user clicked on their second conversation

### DIFF
--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -12,13 +12,19 @@ import 'package:adventures_in_chat_app/extensions/extensions.dart';
 class DatabaseService {
   String currentUserId;
   final Database _database;
+  final _controllers = <String, StreamController<List<MessagesListItem>>>{};
 
   DatabaseService({Database database})
       : _database = database ?? FirestoreDatabase();
 
   Stream<List<MessagesListItem>> getMessagesStream(String conversationId) {
-    // fresh controller per stream.
-    var _controller = StreamController<List<MessagesListItem>>();
+    // fresh controller per unique conversation.
+    StreamController<List<MessagesListItem>> _controller;
+    if (_controllers.containsKey(conversationId)) {
+      _controller = _controllers[conversationId];
+    } else {
+      _controller = StreamController<List<MessagesListItem>>();
+    }
 
     _database.getMessagesStream(conversationId).listen((messagesList) {
       var latest = DateTime.fromMicrosecondsSinceEpoch(0); // init to minimum

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -12,15 +12,18 @@ import 'package:adventures_in_chat_app/extensions/extensions.dart';
 class DatabaseService {
   String currentUserId;
   final Database _database;
-  final _controller = StreamController<List<MessagesListItem>>();
 
   DatabaseService({Database database})
       : _database = database ?? FirestoreDatabase();
 
   Stream<List<MessagesListItem>> getMessagesStream(String conversationId) {
+    // fresh controller per stream.
+    var _controller = StreamController<List<MessagesListItem>>();
+
     _database.getMessagesStream(conversationId).listen((messagesList) {
-      var latest = messagesList.first.timestamp;
-      final newList = <MessagesListItem>[SectionDate(latest)];
+      var latest = DateTime.fromMicrosecondsSinceEpoch(0); // init to minimum
+      final newList = <MessagesListItem>[];
+
       for (final message in messagesList) {
         // if message is first in a new day - insert SectionDate
         if (!message.timestamp.isSameDate(latest)) {
@@ -29,6 +32,7 @@ class DatabaseService {
         }
         newList.add(message);
       }
+
       _controller.add(newList);
     });
 


### PR DESCRIPTION
This is a impulsive fix to a issue that I found while creating a new feature. This was that I was not able to click another conversation once I clicked into the first. I instinctively started to think it was the _controller being reused for all conversations. I almost didn't get this far as I accidently did the fix initially within `_database.getMessagesStream(conversationId).listen((messagesList) {` inner function? And When I tried to return the `_controllers[conversationId].stream I'd get a null exception as the changes within this inner function I suppose it was that it was not in scope. Anyway this seems to work and fixes the bug. I'll add a issue to track this bug now.