### PR TITLE
stream already been listened to when user clicked on their second con…

### DIFF
--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -12,37 +12,30 @@ import 'package:adventures_in_chat_app/extensions/extensions.dart';
 class DatabaseService {
   String currentUserId;
   final Database _database;
-  final _controllers = <String, StreamController<List<MessagesListItem>>>{};
 
   DatabaseService({Database database})
       : _database = database ?? FirestoreDatabase();
 
   Stream<List<MessagesListItem>> getMessagesStream(String conversationId) {
-    // fresh controller per unique conversation.
-    StreamController<List<MessagesListItem>> _controller;
-    if (_controllers.containsKey(conversationId)) {
-      _controller = _controllers[conversationId];
-    } else {
-      _controller = StreamController<List<MessagesListItem>>();
-    }
-
-    _database.getMessagesStream(conversationId).listen((messagesList) {
-      var latest = DateTime.fromMicrosecondsSinceEpoch(0); // init to minimum
-      final newList = <MessagesListItem>[];
+    return _database
+        .getMessagesStream(conversationId)
+        .transform<List<MessagesListItem>>(
+            StreamTransformer.fromHandlers(handleData: (messagesList, sink) {
+      var latest =
+          messagesList.isNotEmpty ? messagesList.first.timestamp : null;
+      final itemsList = <MessagesListItem>[];
 
       for (final message in messagesList) {
         // if message is first in a new day - insert SectionDate
         if (!message.timestamp.isSameDate(latest)) {
           latest = message.timestamp;
-          newList.add(SectionDate(latest));
+          itemsList.add(SectionDate(latest));
         }
-        newList.add(message);
+        itemsList.add(message);
       }
 
-      _controller.add(newList);
-    });
-
-    return _controller.stream;
+      sink.add(itemsList);
+    }));
   }
 
   Future<String> sendMessage({

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -21,9 +21,14 @@ class DatabaseService {
         .getMessagesStream(conversationId)
         .transform<List<MessagesListItem>>(
             StreamTransformer.fromHandlers(handleData: (messagesList, sink) {
-      var latest =
-          messagesList.isNotEmpty ? messagesList.first.timestamp : null;
-      final itemsList = <MessagesListItem>[];
+      // if the list is empty just emit an empty list and return
+      if (messagesList.isEmpty) {
+        sink.add(<MessagesListItem>[]);
+        return;
+      }
+
+      var latest = messagesList.first.timestamp;
+      final itemsList = <MessagesListItem>[SectionDate(latest)];
 
       for (final message in messagesList) {
         // if message is first in a new day - insert SectionDate


### PR DESCRIPTION
#204 was a fix for #205 but is creating a new stream controller every time as it's not using the map to store the controllers.  In my view, we could go in one of a few ways: 
- remove the map stuff to make it clearer the function is creating a new controller every time 
- use the map to store controllers and create broadcast streams instead of single subscription streams 
- use a different approach altogether (eg. RxDart, StreamTransformer) 

This PR is using a StreamTransformer. 

In hindsight I think I should have created a new issue rather than piggy backing on #205, happy to do so if that's preferred. 

Commit Notes: 
- changed to a stream transformer
- after thinking about it a bit I reckon a stream transformer is the way to go - it avoids the need to manage controllers and subscriptions, it was actually my first instinct when we were working on this but at the time I thought it was the more complicated option (although that really wasn't the case) 
- putting this up for discussion 

Fixes #205
- [ ] decide if also fixes #209 