### PR TITLE
add tests for date time extension

### DIFF
--- a/lib/extensions/date_time_extensions.dart
+++ b/lib/extensions/date_time_extensions.dart
@@ -1,5 +1,8 @@
 extension DateOnlyCompare on DateTime {
   bool isSameDate(DateTime other) {
+    if (other == null) {
+      return false;
+    }
     return year == other.year && month == other.month && day == other.day;
   }
 

--- a/test/unit/extensions/date_time_extensions_test.dart
+++ b/test/unit/extensions/date_time_extensions_test.dart
@@ -2,40 +2,47 @@ import 'package:test/test.dart';
 import 'package:adventures_in_chat_app/extensions/extensions.dart';
 
 void main() {
-  group('DateTime', () {
-    test('.isSameDate() returns True when earlier in same day', () {
+  group('DateTime.isSameDate()', () {
+    test('returns True when earlier in same day', () {
       var t0 = DateTime.parse('1969-07-20 20:18:04');
       var t1 = DateTime.parse('1969-07-20 08:28:34');
 
       expect(true, t0.isSameDate(t1));
     });
 
-    test('.isSameDate() returns True when later in same day', () {
+    test('returns True when later in same day', () {
       var t0 = DateTime.parse('1969-07-20 20:18:04');
       var t1 = DateTime.parse('1969-07-20 23:59:34');
 
       expect(true, t0.isSameDate(t1));
     });
 
-    test('.isSameDate() returns False when compared to null', () {
+    test('returns False when compared to null', () {
       var t0 = DateTime.parse('1969-07-20 20:18:04');
       DateTime t1;
 
       expect(false, t0.isSameDate(t1));
-    }, skip: true);
+    }, skip: false);
 
-    test('.isSameDate() returns False when compared to day before', () {
+    test('returns False when compared to day before', () {
       var t0 = DateTime.parse('1969-07-20 20:18:04');
       var t1 = DateTime.parse('1969-07-19 23:59:34');
 
       expect(false, t0.isSameDate(t1));
     });
 
-    test('.isSameDate() returns False when compared to day after', () {
+    test('returns False when compared to day after', () {
       var t0 = DateTime.parse('1969-07-20 20:18:04');
       var t1 = DateTime.parse('1969-07-21 23:59:34');
 
       expect(false, t0.isSameDate(t1));
+    });
+  });
+
+  group('DateTime.printDate()', () {
+    test('returns the date in format day/month/year', () {
+      var t0 = DateTime.parse('1969-07-20 20:18:04');
+      expect(t0.printDate(), '20/7/1969');
     });
   });
 }

--- a/test/unit/extensions/date_time_extensions_test.dart
+++ b/test/unit/extensions/date_time_extensions_test.dart
@@ -1,0 +1,41 @@
+import 'package:test/test.dart';
+import 'package:adventures_in_chat_app/extensions/extensions.dart';
+
+void main() {
+  group('DateTime', () {
+    test('.isSameDate() returns True when earlier in same day', () {
+      var t0 = DateTime.parse('1969-07-20 20:18:04');
+      var t1 = DateTime.parse('1969-07-20 08:28:34');
+
+      expect(true, t0.isSameDate(t1));
+    });
+
+    test('.isSameDate() returns True when later in same day', () {
+      var t0 = DateTime.parse('1969-07-20 20:18:04');
+      var t1 = DateTime.parse('1969-07-20 23:59:34');
+
+      expect(true, t0.isSameDate(t1));
+    });
+
+    test('.isSameDate() returns False when compared to null', () {
+      var t0 = DateTime.parse('1969-07-20 20:18:04');
+      DateTime t1;
+
+      expect(false, t0.isSameDate(t1));
+    });
+
+    test('.isSameDate() returns False when compared to day before', () {
+      var t0 = DateTime.parse('1969-07-20 20:18:04');
+      var t1 = DateTime.parse('1969-07-19 23:59:34');
+
+      expect(false, t0.isSameDate(t1));
+    });
+
+    test('.isSameDate() returns False when compared to day after', () {
+      var t0 = DateTime.parse('1969-07-20 20:18:04');
+      var t1 = DateTime.parse('1969-07-21 23:59:34');
+
+      expect(false, t0.isSameDate(t1));
+    });
+  });
+}

--- a/test/unit/extensions/date_time_extensions_test.dart
+++ b/test/unit/extensions/date_time_extensions_test.dart
@@ -4,36 +4,36 @@ import 'package:adventures_in_chat_app/extensions/extensions.dart';
 void main() {
   group('DateTime.isSameDate()', () {
     test('returns True when earlier in same day', () {
-      var t0 = DateTime.parse('1969-07-20 20:18:04');
+      var t0 = DateTime.parse('1969-07-20 20:17:04');
       var t1 = DateTime.parse('1969-07-20 08:28:34');
 
       expect(true, t0.isSameDate(t1));
     });
 
     test('returns True when later in same day', () {
-      var t0 = DateTime.parse('1969-07-20 20:18:04');
-      var t1 = DateTime.parse('1969-07-20 23:59:34');
+      var t0 = DateTime.parse('1969-07-20 20:17:04');
+      var t1 = DateTime.parse('1969-07-20 23:59:59');
 
       expect(true, t0.isSameDate(t1));
     });
 
     test('returns False when compared to null', () {
-      var t0 = DateTime.parse('1969-07-20 20:18:04');
+      var t0 = DateTime.parse('1969-07-20 20:17:04');
       DateTime t1;
-
-      expect(false, t0.isSameDate(t1));
-    }, skip: false);
-
-    test('returns False when compared to day before', () {
-      var t0 = DateTime.parse('1969-07-20 20:18:04');
-      var t1 = DateTime.parse('1969-07-19 23:59:34');
 
       expect(false, t0.isSameDate(t1));
     });
 
-    test('returns False when compared to day after', () {
-      var t0 = DateTime.parse('1969-07-20 20:18:04');
-      var t1 = DateTime.parse('1969-07-21 23:59:34');
+    test('returns False when compared to day of Saturn V rocket', () {
+      var t0 = DateTime.parse('1969-07-20 20:17:04');
+      var t1 = DateTime.parse('1969-07-16 13:32:34');
+
+      expect(false, t0.isSameDate(t1));
+    });
+
+    test('returns False when compared to day after when Buzz got to walk', () {
+      var t0 = DateTime.parse('1969-07-20 20:17:04');
+      var t1 = DateTime.parse('1969-07-21 02:56:43');
 
       expect(false, t0.isSameDate(t1));
     });
@@ -41,7 +41,7 @@ void main() {
 
   group('DateTime.printDate()', () {
     test('returns the date in format day/month/year', () {
-      var t0 = DateTime.parse('1969-07-20 20:18:04');
+      var t0 = DateTime.parse('1969-07-20 20:17:04');
       expect(t0.printDate(), '20/7/1969');
     });
   });

--- a/test/unit/extensions/date_time_extensions_test.dart
+++ b/test/unit/extensions/date_time_extensions_test.dart
@@ -22,7 +22,7 @@ void main() {
       DateTime t1;
 
       expect(false, t0.isSameDate(t1));
-    });
+    }, skip: true);
 
     test('.isSameDate() returns False when compared to day before', () {
       var t0 = DateTime.parse('1969-07-20 20:18:04');


### PR DESCRIPTION
Attempting to address tests as raised in #201

A little controversial though I did change the implementation to allow for comparing with null. We can back this out if needed and perhaps just keep the `skip: true`

fixes #201 